### PR TITLE
Remove Careers Hyperlinks

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { TeamItemComponent } from './pages/home/team-item.component';
 import { NewsItemComponent } from './pages/home/news-item.component';
 import { PodcastItemComponent } from './pages/home/podcast-item.component';
 import { VideoItemComponent } from './pages/home/video-item.component';
+import { CanActivateCareers } from './pages/careers/prysmatic-careers.page.component';
 
 @NgModule({
   declarations: [
@@ -27,7 +28,7 @@ import { VideoItemComponent } from './pages/home/video-item.component';
     ExternalsModule,
     RouterModule.forRoot(routes)
   ],
-  providers: [],
+  providers: [CanActivateCareers],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/pages/careers/prysmatic-careers.page.component.ts
+++ b/src/app/pages/careers/prysmatic-careers.page.component.ts
@@ -1,4 +1,24 @@
-import { Component } from '@angular/core';
+import { Component, Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import { CanActivate } from '@angular/router/src/utils/preactivation';
+import { ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class CanActivateCareers implements CanActivate {
+  path: ActivatedRouteSnapshot[];
+  route: ActivatedRouteSnapshot;
+  constructor() {}
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree {
+    return environment.hiring;
+  }
+}
+
+
 @Component({
     selector: 'prysmatic-careers-page',
     templateUrl: './prysmatic-careers.page.component.html',

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,7 +1,7 @@
 import {Routes} from '@angular/router';
 import { PrysmaticLabsMasterPageComponent } from './pages/prysmatic-master.page.component';
 import { PrysmaticHomePageComponent } from './pages/home/prysmatic-home.page.component';
-import { PrysmaticCareersPageComponent } from './pages/careers/prysmatic-careers.page.component';
+import { CanActivateCareers, PrysmaticCareersPageComponent } from './pages/careers/prysmatic-careers.page.component';
 
 export const RouteComponents = [
     PrysmaticLabsMasterPageComponent,
@@ -10,5 +10,5 @@ export const RouteComponents = [
 ];
 export const routes: Routes = [
     { path: '', component: PrysmaticHomePageComponent },
-    // { path: 'careers', component: PrysmaticCareersPageComponent },
+    { path: 'careers', component: PrysmaticCareersPageComponent, canActivate: [CanActivateCareers] },
 ];

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -10,5 +10,5 @@ export const RouteComponents = [
 ];
 export const routes: Routes = [
     { path: '', component: PrysmaticHomePageComponent },
-    { path: 'careers', component: PrysmaticCareersPageComponent },
+    // { path: 'careers', component: PrysmaticCareersPageComponent },
 ];

--- a/src/app/shared/prysmatic-footer.component.html
+++ b/src/app/shared/prysmatic-footer.component.html
@@ -4,11 +4,6 @@
             <div class="w-full md:w-1/4">
                 <p class="my-4">Company</p>
                 <div class="py-1">
-                    <a class="text-grey-dark" routerLink="/careers">
-                        Careers
-                    </a>
-                </div>
-                <div class="py-1">
                     <a class="text-grey-dark" href="#news">
                         Media
                     </a>

--- a/src/app/shared/prysmatic-footer.component.html
+++ b/src/app/shared/prysmatic-footer.component.html
@@ -3,6 +3,11 @@
         <div class="px-12 pt-8 pb-12 container text-white flex flex-wrap">
             <div class="w-full md:w-1/4">
                 <p class="my-4">Company</p>
+                <div class="py-1" *ngIf="showCareers()">
+                    <a class="text-grey-dark" routerLink="/careers">
+                        Careers
+                    </a>
+                </div>
                 <div class="py-1">
                     <a class="text-grey-dark" href="#news">
                         Media

--- a/src/app/shared/prysmatic-footer.component.ts
+++ b/src/app/shared/prysmatic-footer.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { faMedium, faGitter,
     faGithub, faTwitter, faDiscord } from '@fortawesome/free-brands-svg-icons';
+import { environment } from '../../environments/environment';
+
 @Component({
     selector: 'prysmatic-footer',
     templateUrl: './prysmatic-footer.component.html',
@@ -12,7 +14,7 @@ export class PrysmaticFooterComponent {
     faGithub = faGithub;
     faTwitter = faTwitter;
     faDiscord = faDiscord;
-    constructor() {
-
+    showCareers(): boolean {
+        return environment.hiring;
     }
 }

--- a/src/app/shared/prysmatic-header.component.html
+++ b/src/app/shared/prysmatic-header.component.html
@@ -25,6 +25,9 @@
         <a class="navbar-item" href="#news">
           News
         </a>
+        <a *ngIf="showCareers()" class="navbar-item" routerLink="/careers">
+          Careers
+        </a>
         <a class="navbar-item" href="https://github.com/prysmaticlabs/prysm" target="_blank">
           Github
         </a>

--- a/src/app/shared/prysmatic-header.component.html
+++ b/src/app/shared/prysmatic-header.component.html
@@ -25,9 +25,6 @@
         <a class="navbar-item" href="#news">
           News
         </a>
-        <a class="navbar-item" routerLink="/careers">
-          Careers
-        </a>
         <a class="navbar-item" href="https://github.com/prysmaticlabs/prysm" target="_blank">
           Github
         </a>

--- a/src/app/shared/prysmatic-header.component.ts
+++ b/src/app/shared/prysmatic-header.component.ts
@@ -10,6 +10,7 @@ import {
   faBlog,
   faNewspaper,
 } from '@fortawesome/free-solid-svg-icons';
+import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'prysmatic-header',
@@ -23,9 +24,11 @@ export class PrysmaticHeaderComponent {
   faBlog = faBlog;
   faNewspaper = faNewspaper;
   faDiscord = faDiscord;
-
-  menuStatus:boolean = false;
-  toggleMenu(){
+  menuStatus = false;
+  toggleMenu() {
     this.menuStatus = !this.menuStatus;
+  }
+  showCareers(): boolean {
+    return environment.hiring;
   }
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  hiring: false,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  hiring: false,
 };
 
 /*


### PR DESCRIPTION
Given we just finished our round of hiring, we can remove the hyperlinks to the careers page on our website