### PR TITLE
Serenity -> Ethereum 2.0 and adjust for mainnet/pyrmont

### DIFF
--- a/src/app/pages/home/prysmatic-home.page.component.html
+++ b/src/app/pages/home/prysmatic-home.page.component.html
@@ -43,7 +43,7 @@
                   Projects at the Cutting-Edge
                </div>
                <div class="py-4 px-8">
-                   Our flagship project, <a class="text-primary" href="https://cryptocurrencyfacts.com/ethereum-2-0-explained/" target="_blank">Prysm</a>, is a production client for <a class="text-primary" href="https://blog.sfox.com/ethereum-2-0-what-the-next-three-years-of-ethereum-will-look-like-b366a46f9704">Ethereum Serenity</a> anyone can freely use to participate in consensus of the blockchain.
+                   Our flagship project, <a class="text-primary" href="https://cryptocurrencyfacts.com/ethereum-2-0-explained/" target="_blank">Prysm</a>, is a production client for <a class="text-primary" href="https://ethereum.org/en/eth2/">Ethereum 2.0</a> anyone can freely use to participate in consensus of the blockchain.
                </div>
            </div>
             <div class="w-full md:w-1/3 pt-4">
@@ -79,7 +79,7 @@
                     <span class="text-primary">Why</span> Ethereum?
                 </h2>
                 <div class="text-white">
-                    We are strong believers in Ethereum, a public blockchain that allows anyone to build unstoppable, censorship-resistant applications. On Ethereum, anyone can deploy software that controls digital value and is accessible around the world. Born in 2014, the Ethereum network houses over $20 billion worth of value today, hosting projects such as:
+                    We are strong believers in Ethereum, a public blockchain that allows anyone to build unstoppable, censorship-resistant applications. On Ethereum, anyone can deploy software that controls digital value and is accessible around the world. Born in 2014, the Ethereum network houses over $60 billion worth of value today, hosting projects such as:
                     <ul class="py-4">
                         <li>
                             <span class="text-xl">—</span> Global, decentralized organizations
@@ -129,9 +129,9 @@
                         <h2 class="card-title text-3xl">
                             <a href="https://github.com/prysmaticlabs/prysm" class="text-grey-darkest">Prysm</a>
                         </h2>
-                        <h4 class="card-subtitle text-grey-darkest text-sm">A full-featured client for the Ethereum Serenity protocol, written in Go</h4>
+                        <h4 class="card-subtitle text-grey-darkest text-sm">A full-featured client for the Ethereum 2.0 protocol, written in Go</h4>
                         <p class="py-4">
-                            The <a class="text-primary" href="https://github.com/prysmaticlabs/prysm">Prysm</a> project is a Go implementation of Ethereum Serenity protocol as detailed by its <a href="https://github.com/ethereum/eth2.0-specs" target="_blank" class="text-primary">official specification</a>. It contains a full beacon node implementation as well as a validator client for participating in blockchain consensus. Prysm utilizes the best-in-class tools for production servers and interprocess communication, using Google's <a href="https://grpc.io/" class="text-primary">gRPC library</a>, BoltDB as an optimized, persistent, key-value store, and <a href="https://libp2p.io/" class="text-primary">libp2p</a> by Protocol Labs for all peer-to-peer networking.
+                            The <a class="text-primary" href="https://github.com/prysmaticlabs/prysm">Prysm</a> project is a Go implementation of the Ethereum 2.0 protocol as detailed by its <a href="https://github.com/ethereum/eth2.0-specs" target="_blank" class="text-primary">official specification</a>. It contains a full beacon node implementation as well as a validator client for participating in blockchain consensus. Prysm utilizes the best-in-class tools for production servers and interprocess communication, using Google's <a href="https://grpc.io/" class="text-primary">gRPC library</a>, BoltDB as an optimized, persistent, key-value store, and <a href="https://libp2p.io/" class="text-primary">libp2p</a> by Protocol Labs for all peer-to-peer networking.
                         </p>
                         <div>
                             <a class="button is-primary is-narrow shadow" target="_blank" href="https://docs.prylabs.network">Read the Docs</a>
@@ -150,11 +150,11 @@
                     </div>
                     <div class="w-full px-6 pt-4 pb-8">
                         <h2 class="text-2xl">
-                            <a href="https://prylabs.net" class="text-grey-darkest">Eth2 Mainnet Phase 0</a>
+                            <a href="https://launchpad.ethereum.org/" class="text-grey-darkest">Eth2 Mainnet Phase 0</a>
                         </h2>
                         <h4 class="text-grey-darkest text-sm">The official release of eth2</h4>
                         <p class="py-4">
-                            Scheduled to launch December 2020, eth2 is a publicly accessible network running multiple client implementations participating in Ethereum 2.0 consensus based on the <a class="text-primary" href="https://github.com/ethereum/eth2.0-specs" target="_blank">formal specification</a> for the protocol. The official and only validator deposit contract is <a target="_blank" class="text-primary" href="https://etherscan.io/address/0x00000000219ab540356cbb839cbe05303d7705fa">0x00000000219ab540356cbb839cbe05303d7705fa</a>.
+                            Launching December 1st 2020, eth2 is a publicly accessible network running multiple client implementations participating in Ethereum 2.0 consensus based on the <a class="text-primary" href="https://github.com/ethereum/eth2.0-specs" target="_blank">formal specification</a> for the protocol. The official and only validator deposit contract is <a target="_blank" class="text-primary" href="https://etherscan.io/address/0x00000000219ab540356cbb839cbe05303d7705fa">0x00000000219ab540356cbb839cbe05303d7705fa</a>.
                             </p>
                         <p class="pb-4">Anyone across the world can sync with the network, stake 32 ETH, and participate in the protocol's consensus.
                         </p>
@@ -173,11 +173,11 @@
                     </div>
                     <div class="w-full px-6 pt-4 pb-8">
                         <h2 class="text-2xl">
-                            <a href="https://github.com/prysmaticlabs/ethereumapis" class="text-grey-darkest">Ethereum Serenity APIs</a>
+                            <a href="https://github.com/prysmaticlabs/ethereumapis" class="text-grey-darkest">Ethereum 2.0 APIs</a>
                         </h2>
-                        <h4 class="text-grey-darkest text-sm">Thoroughly-documented, schema-based API for Ethereum Serenity</h4>
+                        <h4 class="text-grey-darkest text-sm">Thoroughly-documented, schema-based API for Ethereum 2.0</h4>
                         <p class="py-4">
-                            Ethereum Serenity APIs are a collection of schema-based, protobuf APIs aimed to standardize the efforts for a common API interface used to query information about the blockchain.
+                            Our Ethereum 2.0 APIs are a collection of schema-based, protobuf APIs aimed to standardize the efforts for a common API interface used to query information about the blockchain.
                             </p>
                         <p class="pb-4">The API is also used for validator clients to interact with a running node for the sake of consensus.
                         </p>
@@ -219,12 +219,12 @@
         </div>
         <div class="flex justify-center">
             <div class=" md:w-1/2 text-grey-light">
-                Participate as a validator in our public <a href="https://cryptocurrencyfacts.com/ethereum-2-0-explained/" target="_blank" class="font-bold text-primary">Ethereum Serenity</a> test network today - sync with a full <a href="https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ" target="_blank" class="font-bold text-primary">Proof-of-Stake</a> Ethereum blockchain today and help us improve our work on the cutting-edge.
+                Participate as a validator in the public <a href="https://cryptocurrencyfacts.com/ethereum-2-0-explained/" target="_blank" class="font-bold text-primary">Ethereum 2.0</a> test network today - sync with a full <a href="https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ" target="_blank" class="font-bold text-primary">Proof-of-Stake</a> Ethereum blockchain today and help us improve our work on the cutting-edge.
             </div>
         </div>
         <div class="flex justify-center mt-6">
             <div class=" md:w-1/2">
-                <a class="read-more-btn bg-primary button text-white" href="https://prylabs.net" target="_blank">
+                <a class="read-more-btn bg-primary button text-white" href=https://docs.prylabs.network/docs/testnet/pyrmont target="_blank">
                     Participate Today
                 </a>
             </div>

--- a/src/app/pages/home/prysmatic-home.page.component.html
+++ b/src/app/pages/home/prysmatic-home.page.component.html
@@ -224,7 +224,7 @@
         </div>
         <div class="flex justify-center mt-6">
             <div class=" md:w-1/2">
-                <a class="read-more-btn bg-primary button text-white" href=https://docs.prylabs.network/docs/testnet/pyrmont target="_blank">
+                <a class="read-more-btn bg-primary button text-white" href="https://docs.prylabs.network/docs/testnet/pyrmont" target="_blank">
                     Participate Today
                 </a>
             </div>

--- a/src/app/pages/home/prysmatic-home.page.component.ts
+++ b/src/app/pages/home/prysmatic-home.page.component.ts
@@ -89,10 +89,10 @@ export class PrysmaticHomePageComponent {
             caption: 'Phase 0 of eth2 is scheduled to launch December 2020, with the deposit contract now live...',
         },
         {
-          title: 'Ethereum Foundation Grants $750,000 to Prysmatic Labs for Work on Ethereum Serenity',
+          title: 'Ethereum Foundation Grants $750,000 to Prysmatic Labs for Work on Ethereum 2.0',
           photo: 'ethgrant.png',
           url: 'https://blog.ethereum.org/2019/08/26/announcing-ethereum-foundation-and-co-funded-grants/',
-          caption: 'We are today unveiling over $2M USD in Foundation-led and co-funded grant funding aimed at furthering Serenity (Eth2.0)...',
+          caption: 'We are today unveiling over $2M USD in Foundation-led and co-funded grant funding aimed at furthering Ethereum 2.0...',
         },
         {
             title: 'Ethereum Gets Second ETH 2.0 Testnet Courtesy of Prysmatic Labs',

--- a/src/app/shared/prysmatic-footer.component.html
+++ b/src/app/shared/prysmatic-footer.component.html
@@ -65,13 +65,13 @@
                     </a>
                 </div>
                 <div class="py-1">
-                    <a class="text-grey-dark" href="https://prylabs.net">
-                       Ethereum Serenity Public Testnet
+                    <a class="text-grey-dark" href="https://docs.prylabs.network/docs/mainnet/joining-eth2">
+                       Ethereum 2.0 Mainnet
                     </a>
                 </div>
                 <div class="py-1">
                     <a class="text-grey-dark" href="https://github.com/prysmaticlabs/ethereumapis">
-                        Ethereum Serenity APIs
+                        Ethereum 2.0 APIs
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
This PR updates all mentions of Ethereum Serenity to Ethereum 2.0, adjusts verbiage for the imminent mainnet and updates testnet relevant links/info to pyrmont.