### PR TITLE
Replace 'embedded' with 'go' security engineer

### DIFF
--- a/src/app/pages/careers/prysmatic-careers.page.component.html
+++ b/src/app/pages/careers/prysmatic-careers.page.component.html
@@ -12,7 +12,7 @@
                         <a href="/careers/frontend" class="text-lg">Frontend Software Engineer</a>
                     </li>
                     <li>
-                        <a href="/careers/security" class="text-lg">Embedded Security Engineer</a>
+                        <a href="/careers/security" class="text-lg">Go Security Engineer</a>
                     </li>
                     <li>
                         <a href="/careers/sdet" class="text-lg">Software Development Engineer In Test (SDET)</a>

--- a/src/app/pages/careers/security/prysmatic-careers-security.page.component.ts
+++ b/src/app/pages/careers/security/prysmatic-careers-security.page.component.ts
@@ -9,8 +9,8 @@ import { JobPost } from '../../../models/job-post';
 })
 export class PrysmaticCareersSecurityPageComponent {
     post: JobPost = {
-        title: 'Embedded Security Engineer',
-        lookingFor: 'We are looking for a remote, full-time embedded security engineer to keep pushing the envelope on decentralized technologies. Particularly, having experience in penetration testing and Golang is a huge plus.',
+        title: 'Go Security Engineer',
+        lookingFor: 'We are looking for a remote, full-time go security engineer to keep pushing the envelope on decentralized technologies. Particularly, having experience in penetration testing and Golang is a huge plus.',
         requirements: [
           'Experience in security and/or penetration testing',
           'Significant experience as a software engineer, having worked on a team, participated in the design and code review process, and having not only shipped products, but successfully landed them',


### PR DESCRIPTION
"Embedded" security engineer may be misunderstood as embedded systems engineer. Our intention is that we want a security engineer that is part of the core development team to provide continuous security support. 
This PR removes the word "embedded" and replaces it with "go" to reduce potential confusion.
